### PR TITLE
Fix cli and openai

### DIFF
--- a/chatarena/backends/openai.py
+++ b/chatarena/backends/openai.py
@@ -94,5 +94,11 @@ class OpenAIChat(IntelligenceBackend):
         prefix = f"[{agent_name}]:"
         if response.startswith(prefix):
             response = response[len(prefix):].strip()
+        
+        # Remove the first response of other players
+        if response.startswith('['):
+            response = response[response.index(']'):].strip()
+        # A case for incorrectly appended utterances
+        response =  re.split('\[.+\]',response)[0].strip()
 
         return response

--- a/chatarena/ui/cli.py
+++ b/chatarena/ui/cli.py
@@ -116,7 +116,8 @@ class ArenaCLI:
                         [('class:user_prompt', f"Type your input for {human_player_name}: ")],
                         style=Style.from_dict({'user_prompt': 'ansicyan underline'})
                     )
-                    env.step(human_player_name, human_input)
+                    # If not, the conversation does not stop
+                    timestep = env.step(human_player_name, human_input)
                 else:
                     raise e  # cannot recover from this error in non-interactive mode
             except TooManyInvalidActions as e:


### PR DESCRIPTION
Fixed 2 bugs.

1. backends/openai.py
- To remove the incorrect responses.
```
if response.startswith('['):
  response = response[response.index(']'):].strip()
            
response =  re.split('\[.+\]',response)[0].strip()
```
- For the first case, there are some cases '[Player 2]' is prepended to the response of Player 1.
- For the second case, there are some cases where the responses of other players are appended.

2. ui/cli.py
- To stop the conversation.
```
timestep = env.step(human_player_name, human_input)
```
- Without assigning 'timestep' to the human input, the conversation does not terminate when it should.