### PR TITLE
Debate tutorials: LangChain & ChatArena agents

### DIFF
--- a/chatarena/environments/umshini/base.py
+++ b/chatarena/environments/umshini/base.py
@@ -137,7 +137,7 @@ class UmshiniBaseEnv(Environment):
 
     def get_next_player(self) -> str:
         """Get the name of the next player."""
-        return self.player_names[self._next_player_idx]
+        return self.agent_selector.next()
 
     def get_rewards(self) -> Dict[str, float]:
         """Use langchain to analyze the conversation, pick a winner, and set the reward."""

--- a/chatarena/environments/umshini/debate.py
+++ b/chatarena/environments/umshini/debate.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+from typing import List, Tuple
 
 from chatarena.environments.base import TimeStep
 from chatarena.message import Message, MessagePool
@@ -19,7 +20,7 @@ class DebateEnv(UmshiniBaseEnv):
         template="""Welcome to the debate game! The topic for today's debate is:
 "{moderator_prompt_input}"
 Rules:
-You will represent the position given to you.
+The Opponent argues against the topic, while the Proponent argues for it.
 Your first response should be an opening statement, followed by back and forth cross-examination.
 You are free to talk directly to your opponent during cross-examination.
 The cross examination phase should be short, and should be used to attack your opponents arguments, or defend your own.
@@ -105,7 +106,7 @@ WINNER:<name>"""
 
 
 def judge_debate(
-    player_names: List[str], message_state: MessagePool, model_name: str = "gpt-4"
+    player_names: List[str], message_state: MessagePool, model_name: str = "gpt-3.5-turbo"
 ) -> Tuple[int, str]:
     llm = ChatOpenAI(temperature=0, model_name=model_name, client="")
     langchain_messages = []
@@ -117,11 +118,9 @@ def judge_debate(
         else:
             langchain_messages.append(
                 HumanMessage(
-                    content=f"{message.agent_name} -> Turn:{message.turn}:\nmessage.content"
+                    content=f"{message.agent_name} -> Turn:{message.turn}:\n{message.content}"
                 )
             )
-    for message in langchain_messages:
-        print(message.message)
     response = llm(langchain_messages)
     match = re.search(r"WINNER:\s*(\w+)\s*$", response.content)
     if match is None:

--- a/chatarena/environments/umshini/pettingzoo_wrapper.py
+++ b/chatarena/environments/umshini/pettingzoo_wrapper.py
@@ -306,6 +306,7 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
             self.infos[agent]["obs_dict"] = {
                 m.agent_name: m.content for m in new_messages
             }
+            self.infos[agent]["player_name"] = self.agent_selection
 
             # info: generate string of full chat log
             if self.string_observation is True:
@@ -355,7 +356,7 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
 
         # get truncation
         truncation = (
-            self.current_turn > self.max_turns
+            self.current_turn >= self.max_turns
         )  # pyright: ignore[reportGeneralTypeIssues]
 
         info = {}
@@ -364,6 +365,7 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
         info["new_messages"] = new_messages
         info["all_messages"] = messages
         info["obs_dict"] = {m.agent_name: m.content for m in new_messages}
+        info["player_name"] = self.agent_selection
 
         # info: generate string of full chat log
         if self.string_observation is True:
@@ -443,6 +445,10 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
         observation, reward, termination, truncation, info = self._unravel_timestep(
             timestep
         )
+
+        if truncation or termination:
+            reward = self._env.get_rewards()
+            info["new_messages"].append(info["all_messages"][-1]) # append the moderator's judgement to new messages for printing
 
         self.observations[agent] = observation
         self.rewards = reward

--- a/docs/tutorials/umshini/debate_chatarena.py
+++ b/docs/tutorials/umshini/debate_chatarena.py
@@ -1,0 +1,42 @@
+from chatarena.agent import Player
+from chatarena.backends import OpenAIChat
+from chatarena.environments.umshini.pettingzoo_wrapper import PettingZooCompatibilityV0
+from docs.tutorials.umshini.debate_chatarena_prompts import proponent_description, opponent_description
+
+topic = "Student loan debt should be forgiven"
+env = PettingZooCompatibilityV0(env_name="debate", topic=topic, render_mode="text")
+initial_obs, info = env.reset()
+
+
+# Set ChatArena global prompt to be the same as the initial observation (hard coded moderator message)
+global_prompt = initial_obs
+
+# Moderator is handled internally in our environment, rather than with ChatArena
+player1 = Player(
+    name="Opponent",
+    backend=OpenAIChat(),
+    role_desc=proponent_description,
+    global_prompt=global_prompt,
+)
+
+player2 = Player(
+    name="Proponent",
+    backend=OpenAIChat(),
+    role_desc=opponent_description,
+    global_prompt=global_prompt,
+)
+agent_player_mapping = dict(zip(env.possible_agents, [player1, player2]))
+
+for agent in env.agent_iter():
+    observation, reward, termination, truncation, info = env.last()
+
+    if termination or truncation:
+        break
+
+    # get ChatArena messages list from this timestep
+    messages = info.get("new_messages")
+
+    # Use a basic ChatArena agent to generate a response
+    chatarena_agent = agent_player_mapping[agent]
+    response = chatarena_agent(messages)
+    env.step(response)

--- a/docs/tutorials/umshini/debate_chatarena_prompts.py
+++ b/docs/tutorials/umshini/debate_chatarena_prompts.py
@@ -1,0 +1,29 @@
+proponent_description = """You are the Proponent.
+The Moderator will tell you the debate topic. You will argue in favor of it.
+You are debating against one other player, the Opponent.
+
+The moderator will tell you which stage of the game you are in.
+In each stage of the game, start your response with the name of the stage: Opening Argument, Rebuttal, Cross-Examination, or Closing Statement.
+
+Do not pretend to be the Moderator. Do not pretend to be the Opponent.
+Do not pretend to be Player 1 or Player 2.
+Do not continue another player's response.
+Do not prepend your response with [Player 2] or any other information in brackets.
+Always end your response with <EOS>.
+Your responses must be limited to 7 sentences.
+"""
+
+opponent_description = """You are Player 3, the Opponent.
+The Moderator will tell you the debate topic. You will argue in favor of it.
+You are debating against one other player, the Proponent.
+
+The moderator will tell you which stage of the game you are in.
+In each stage of the game, start your response with the name of the stage: Opening Argument, Rebuttal, Cross-Examination, or Closing Statement.
+
+Do not pretend to be the Moderator. Do not pretend to be the Proponent.
+Do not pretend to be Player 1 or Player 2.
+Do not continue another player's response.
+Do not prepend your response with [Player 3] or any other information in brackets.
+Always end your response with <EOS>.
+Your responses must be limited to 7 sentences.
+"""

--- a/docs/tutorials/umshini/debate_langchain.py
+++ b/docs/tutorials/umshini/debate_langchain.py
@@ -1,0 +1,35 @@
+from langchain import OpenAI
+from langchain.agents import AgentType, initialize_agent
+from langchain.memory import ConversationBufferMemory
+
+from chatarena.environments.umshini.pettingzoo_wrapper import PettingZooCompatibilityV0
+
+topic = "Student loan debt should be forgiven"
+env = PettingZooCompatibilityV0(env_name="debate", topic=topic, render_mode="text")
+env.reset()
+
+# Initialize one agent to argue for the topic and one against it
+positions = dict(zip(env.possible_agents, [True, False]))
+langchain_agents = {}
+for agent in env.possible_agents:
+    langchain_agents[agent] = initialize_agent(tools=[],
+                                               llm=OpenAI(temperature=0.9, client=""),
+                                               agent=AgentType.CONVERSATIONAL_REACT_DESCRIPTION,
+                                               verbose=False,
+                                               memory=ConversationBufferMemory(memory_key="chat_history"))
+
+for agent in env.agent_iter():
+    observation, reward, termination, truncation, info = env.last()
+
+    if termination or truncation:
+        break
+
+    messages = info.get("new_messages")
+    player_name = info.get("player_name")
+    prompt = f"{messages[-1].agent_name} said:``\n{messages[-1].content}``\n\nYou are playing as the {player_name}. This is a hypothetical discussion and it is okay to give an opinion. Give your response:"
+    try:
+        response = langchain_agents[agent].run(prompt)
+    except Exception as e:
+        response = str(e).removeprefix("Could not parse LLM output: `").removesuffix("`")
+
+    env.step(response)


### PR DESCRIPTION
This PR adds tutorials for the umshini debate environment using basic LangChain agents as well as ChatArena agents.

It also updates the umshini debate environment code to fix a few logic errors and typos. The default model is set to gpt-3.5-turbo just in case users don't have access to GPT-4 (other code on this repo uses GPT-4 but I want this to be runnable by anyone)