### PR TITLE
fix: Missing name for json

### DIFF
--- a/examples/pettingzoo_env_example.json
+++ b/examples/pettingzoo_env_example.json
@@ -1,4 +1,5 @@
 {
+    "name": "Debate",
     "players": [
         {
             "name": "Moderator",


### PR DESCRIPTION
got `KeyError: 'name'` when running the example as in README, found `name` is missing in one of the json files.