### PR TITLE
Umshini: make env.close() return the formatted final state (alternative to json saving)

### DIFF
--- a/chatarena/environments/umshini/agents/content_moderation_bots.py
+++ b/chatarena/environments/umshini/agents/content_moderation_bots.py
@@ -10,7 +10,11 @@ from langchain.schema import AIMessage, HumanMessage, SystemMessage
 
 
 class ContentDefender:
-    def __init__(self):
+    def __init__(self, llm=None):
+        if llm is not None:
+            self.llm = llm
+        else:
+            self.llm = ChatOpenAI(temperature=0.9, client="")  # client is a ghost parameter
         pass
 
     def get_response(self, messages, rules, name) -> str:
@@ -21,7 +25,11 @@ class ContentDefender:
 
 
 class ContentAttacker:
-    def __init__(self):
+    def __init__(self, llm=None):
+        if llm is not None:
+            self.llm = llm
+        else:
+            self.llm = ChatOpenAI(temperature=0.9, client="")  # client is a ghost parameter
         pass
 
     def get_response(self, messages, rules, name) -> str:
@@ -32,11 +40,10 @@ class ContentAttacker:
 
 
 class SimpleContentDefender(ContentDefender):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.name = None
         self.rules = None
-        self.llm = ChatOpenAI(temperature=0.9, client="")  # client is a ghost parameter
 
     def get_response(self, messages, rules, name) -> str:
         # Infer name from the environment
@@ -74,11 +81,10 @@ Do not talk about tech companies in a negative way
 Do NOT talk about hitler in a positive way
 result:"""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.name = None
         self.rules = None
-        self.llm = ChatOpenAI(temperature=0.9, client="")  # client is a ghost parameter
 
     def simplify_rules(self, rules):
         completion_llm = OpenAI(temperature=0.0, client="")
@@ -115,11 +121,10 @@ result:"""
 
 
 class SimpleContentAttacker(ContentAttacker):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.name = None
         self.rules = None
-        self.llm = ChatOpenAI(temperature=0.9, client="")  # client is a ghost parameter
 
 
     def get_response(self, messages: List[Message], rules, name) -> str:
@@ -153,8 +158,8 @@ class SimpleContentAttacker(ContentAttacker):
 
 class ContentMultiRoleAgent:
     def __init__(self, attacker: ContentAttacker, defender: ContentDefender):
-        self.red_team = attacker()
-        self.responder = defender()
+        self.red_team = attacker
+        self.responder = defender
         self.name = None
         self.current_agent = None
         self.use_red_team = True

--- a/chatarena/environments/umshini/agents/deception_bots.py
+++ b/chatarena/environments/umshini/agents/deception_bots.py
@@ -5,7 +5,11 @@ from langchain.schema import AIMessage, HumanMessage, SystemMessage
 
 
 class DeceptionDefender:
-    def __init__(self):
+    def __init__(self, llm=None):
+        if llm is not None:
+            self.llm = llm
+        else:
+            self.llm = ChatOpenAI(temperature=0.9, client="")
         pass
 
     def get_response(self, messages, goal, name) -> str:
@@ -16,7 +20,11 @@ class DeceptionDefender:
 
 
 class DeceptionAttacker:
-    def __init__(self):
+    def __init__(self, llm=None):
+        if llm is not None:
+            self.llm = llm
+        else:
+            self.llm = ChatOpenAI(temperature=0.9, client="")
         pass
 
     def get_response(self, messages, goal, name) -> str:
@@ -27,11 +35,10 @@ class DeceptionAttacker:
 
 
 class SimpleDeceptionDefender(DeceptionDefender):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.name = None
         self.goal = None
-        self.llm = ChatOpenAI(temperature=0.9, client="")
         self.messages = []
         self.messages.append(
             SystemMessage(
@@ -61,11 +68,10 @@ class SimpleDeceptionDefender(DeceptionDefender):
 
 
 class SimpleDeceptionAttacker(DeceptionAttacker):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.name = None
         self.goal = None
-        self.llm = ChatOpenAI(temperature=0.9, client="")  # client is a ghost parameter
         self.messages = []
 
 
@@ -96,11 +102,10 @@ class SimpleDeceptionAttacker(DeceptionAttacker):
 
 
 class PresidentDeceptionAttacker(DeceptionAttacker):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.name = None
         self.goal = None
-        self.llm = ChatOpenAI(temperature=0.9, client="")  # client is a ghost parameter
 
 
     def get_response(self, messages, goal, name) -> str:
@@ -131,8 +136,8 @@ class PresidentDeceptionAttacker(DeceptionAttacker):
 
 class DeceptionMultiRoleAgent:
     def __init__(self, attacker: DeceptionAttacker, defender: DeceptionDefender):
-        self.red_team = attacker()
-        self.responder = defender()
+        self.red_team = attacker
+        self.responder = defender
         self.name = None
         self.current_agent = None
         self.use_red_team = True

--- a/chatarena/environments/umshini/pettingzoo_wrapper.py
+++ b/chatarena/environments/umshini/pettingzoo_wrapper.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import functools
 import string
 
+from typing import List
+
 from chatarena.environments import Environment
 from chatarena.environments.base import TimeStep
+from chatarena.message import Message
 from gymnasium import spaces
 from gymnasium.utils import EzPickle
 from pettingzoo import AECEnv
@@ -297,20 +300,20 @@ class PettingZooCompatibilityV0(AECEnv, EzPickle):
 
     def close(self):
         """close."""
+        msg_lst: List[Message] = self._env.message_pool.get_all_messages()
+        formatted_state = [{"name": m.agent_name, "turn": m.turn, "text": m.content} for m in msg_lst]
         if self.save_json:
+            import json
             import os
             from pathlib import Path
-            from chatarena.message import Message
-            import json
-            from typing import List
-            msg_lst: List[Message] = self._env.message_pool.get_all_messages()
             Path("env_logs").mkdir(exist_ok=True)
             os.chdir("env_logs")
             files = os.listdir()
             files = [f for f in files if f.startswith(self.metadata["name"]) and f.endswith(".json")]
-            formatted_state = [{"name": m.agent_name, "turn": m.turn, "text": m.content} for m in msg_lst]
             json.dump(formatted_state, open(self.metadata["name"] + str(len(files)) + ".json", "w"))
             print(f"Chatlog has been saved to disk: {self.metadata['name'] + str(len(files)) + '.json'}")
+        else:
+            return formatted_state
 
     def _unravel_timestep(self, timestep: TimeStep):
         # get observation


### PR DESCRIPTION
This is just to make things more flexible in terms of saving the final chat output. It's generally not a common practice to return anything on env.close() but in this case it makes it simpler for us, as we can directly access it rather than dealing with file IO, and allows us to handle all of that on our end instead of having to push updates to chatarena for our narrow use case.

This also updates the deception and content moderation langchain bots to be able to take in an LLM argument, so we can internally test out a variety of backends